### PR TITLE
Separate data from code (closes #8)

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -1,0 +1,147 @@
+{
+  "list": [
+    {
+      "location": "Austria",
+      "lat_lng": [ 48.2083537, 16.3725042 ],
+      "post_nr": 4
+    }
+    ,
+    {
+      "location": "Spain",
+      "lat_lng": [ 41.3825596, 2.1771353 ],
+      "post_nr": 5
+    }
+    ,
+    {
+      "location": "Aachen",
+      "lat_lng": [ 50.776351, 6.0838618 ],
+      "post_nr": 6
+    }
+    ,
+    {
+      "location": "Stuttgart",
+      "lat_lng": [ 48.7784485, 9.1800132 ],
+      "post_nr": 7
+    }
+    ,
+    {
+      "location": "Düsseldorf",
+      "lat_lng": [ 51.2254018, 6.7763137 ],
+      "post_nr": 8
+    }
+    ,
+    {
+      "location": "Franken",
+      "lat_lng": [ 49.4538723, 11.0772978 ],
+      "post_nr": 11
+    }
+    ,
+    {
+      "location": "Augsburg",
+      "lat_lng": [ 48.3668041, 10.8986971 ],
+      "post_nr": 12
+    }
+    ,
+    {
+      "location": "Paris",
+      "lat_lng": [ 48.8566101, 2.3514992 ],
+      "post_nr": 13
+    }
+    ,
+    {
+      "location": "Aarau",
+      "lat_lng": [ 47.3927146, 8.0444448 ],
+      "post_nr": 14
+    }
+    ,
+    {
+      "location": "Bremen",
+      "lat_lng": [ 53.0758196, 8.8071646 ],
+      "post_nr": 15
+    }
+    ,
+    {
+      "location": "Ulm",
+      "lat_lng": [ 48.3973944, 9.9932755 ],
+      "post_nr": 17
+    }
+    ,
+    {
+      "location": "Hamburg",
+      "lat_lng": [ 53.5503414, 10.000654 ],
+      "post_nr": 20
+    }
+    ,
+    {
+      "location": "Leiden",
+      "lat_lng": [ 52.1598645, 4.4824271 ],
+      "post_nr": 21
+    }
+    ,
+    {
+      "location": "Canada",
+      "lat_lng": [ 43.6529206, -79.3849007 ],
+      "post_nr": 22
+    }
+    ,
+    {
+      "location": "München",
+      "lat_lng": [ 48.1371079, 11.5753822 ],
+      "post_nr": 23
+    }
+    ,
+    {
+      "location": "Berlin",
+      "lat_lng": [ 52.5170365, 13.3888599 ],
+      "post_nr": 24
+    }
+    ,
+    {
+      "location": "Israel",
+      "lat_lng": [ 32.0804808, 34.7805274 ],
+      "post_nr": 25
+    }
+    ,
+    {
+      "location": "United Kingdom",
+      "lat_lng": [ 51.5073, -0.1277 ],
+      "post_nr": 28
+    }
+    ,
+    {
+      "location": "Sweden",
+      "lat_lng": [ 63.8256568, 20.2630745 ],
+      "post_nr": 29
+    }
+    ,
+    {
+      "location": "Turkey",
+      "lat_lng": [ 41.0096334, 28.9651646 ],
+      "post_nr": 31
+    }
+    ,
+    {
+      "location": "Strasbourg",
+      "lat_lng": [ 48.56908, 7.7621 ],
+      "post_nr": 32
+    }
+    ,
+    {
+      "location": "Tilburg",
+      "lat_lng": [ 51.58508, 5.06369 ],
+      "post_nr": 33
+    }
+    ,
+    {
+      "location": "Saarbrücken",
+      "lat_lng": [ 49.24717, 6.98287 ],
+      "post_nr": 34
+    }
+    ,
+    {
+      "location": "Grenoble",
+      "lat_lng": [ 45.182478, 5.7210773 ],
+      "post_nr": 35
+    }
+  ]
+}

--- a/communities.json
+++ b/communities.json
@@ -1,147 +1,83 @@
+---
+# GitHub Pages process this file through Jekyll,
+# which transforms this header into a valid JSON
+
+# Source: https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815
+
+fairphone_local_communities:
+  - location: Austria
+    lat_lng: [48.2083537, 16.3725042]
+    post_nr: 4
+  - location: Spain
+    lat_lng: [41.3825596, 2.1771353]
+    post_nr: 5
+  - location: Aachen
+    lat_lng: [50.776351, 6.0838618]
+    post_nr: 6
+  - location: Stuttgart
+    lat_lng: [48.7784485, 9.1800132]
+    post_nr: 7
+  - location: Düsseldorf
+    lat_lng: [51.2254018, 6.7763137]
+    post_nr: 8
+  - location: Franken
+    lat_lng: [49.4538723, 11.0772978]
+    post_nr: 11
+  - location: Augsburg
+    lat_lng: [48.3668041, 10.8986971]
+    post_nr: 12
+  - location: Paris
+    lat_lng: [48.8566101, 2.3514992]
+    post_nr: 13
+  - location: Aarau
+    lat_lng: [47.3927146, 8.0444448]
+    post_nr: 14
+  - location: Bremen
+    lat_lng: [53.0758196, 8.8071646]
+    post_nr: 15
+  - location: Ulm
+    lat_lng: [48.3973944, 9.9932755]
+    post_nr: 17
+  - location: Hamburg
+    lat_lng: [53.5503414, 10.000654]
+    post_nr: 20
+  - location: Leiden
+    lat_lng: [52.1598645, 4.4824271]
+    post_nr: 21
+  - location: Canada
+    lat_lng: [43.6529206, -79.3849007]
+    post_nr: 22
+  - location: München
+    lat_lng: [48.1371079, 11.5753822]
+    post_nr: 23
+  - location: Berlin
+    lat_lng: [52.5170365, 13.3888599]
+    post_nr: 24
+  - location: Israel
+    lat_lng: [32.0804808, 34.7805274]
+    post_nr: 25
+  - location: United Kingdom
+    lat_lng: [51.5073, -0.1277]
+    post_nr: 28
+  - location: Sweden
+    lat_lng: [63.8256568, 20.2630745]
+    post_nr: 29
+  - location: Turkey
+    lat_lng: [41.0096334, 28.9651646]
+    post_nr: 31
+  - location: Strasbourg
+    lat_lng: [48.56908, 7.7621]
+    post_nr: 32
+  - location: Tilburg
+    lat_lng: [51.58508, 5.06369]
+    post_nr: 33
+  - location: Saarbrücken
+    lat_lng: [49.24717, 6.98287]
+    post_nr: 34
+  - location: Grenoble
+    lat_lng: [45.182478, 5.7210773]
+    post_nr: 35
+---
 {
-  "list": [
-    {
-      "location": "Austria",
-      "lat_lng": [ 48.2083537, 16.3725042 ],
-      "post_nr": 4
-    }
-    ,
-    {
-      "location": "Spain",
-      "lat_lng": [ 41.3825596, 2.1771353 ],
-      "post_nr": 5
-    }
-    ,
-    {
-      "location": "Aachen",
-      "lat_lng": [ 50.776351, 6.0838618 ],
-      "post_nr": 6
-    }
-    ,
-    {
-      "location": "Stuttgart",
-      "lat_lng": [ 48.7784485, 9.1800132 ],
-      "post_nr": 7
-    }
-    ,
-    {
-      "location": "Düsseldorf",
-      "lat_lng": [ 51.2254018, 6.7763137 ],
-      "post_nr": 8
-    }
-    ,
-    {
-      "location": "Franken",
-      "lat_lng": [ 49.4538723, 11.0772978 ],
-      "post_nr": 11
-    }
-    ,
-    {
-      "location": "Augsburg",
-      "lat_lng": [ 48.3668041, 10.8986971 ],
-      "post_nr": 12
-    }
-    ,
-    {
-      "location": "Paris",
-      "lat_lng": [ 48.8566101, 2.3514992 ],
-      "post_nr": 13
-    }
-    ,
-    {
-      "location": "Aarau",
-      "lat_lng": [ 47.3927146, 8.0444448 ],
-      "post_nr": 14
-    }
-    ,
-    {
-      "location": "Bremen",
-      "lat_lng": [ 53.0758196, 8.8071646 ],
-      "post_nr": 15
-    }
-    ,
-    {
-      "location": "Ulm",
-      "lat_lng": [ 48.3973944, 9.9932755 ],
-      "post_nr": 17
-    }
-    ,
-    {
-      "location": "Hamburg",
-      "lat_lng": [ 53.5503414, 10.000654 ],
-      "post_nr": 20
-    }
-    ,
-    {
-      "location": "Leiden",
-      "lat_lng": [ 52.1598645, 4.4824271 ],
-      "post_nr": 21
-    }
-    ,
-    {
-      "location": "Canada",
-      "lat_lng": [ 43.6529206, -79.3849007 ],
-      "post_nr": 22
-    }
-    ,
-    {
-      "location": "München",
-      "lat_lng": [ 48.1371079, 11.5753822 ],
-      "post_nr": 23
-    }
-    ,
-    {
-      "location": "Berlin",
-      "lat_lng": [ 52.5170365, 13.3888599 ],
-      "post_nr": 24
-    }
-    ,
-    {
-      "location": "Israel",
-      "lat_lng": [ 32.0804808, 34.7805274 ],
-      "post_nr": 25
-    }
-    ,
-    {
-      "location": "United Kingdom",
-      "lat_lng": [ 51.5073, -0.1277 ],
-      "post_nr": 28
-    }
-    ,
-    {
-      "location": "Sweden",
-      "lat_lng": [ 63.8256568, 20.2630745 ],
-      "post_nr": 29
-    }
-    ,
-    {
-      "location": "Turkey",
-      "lat_lng": [ 41.0096334, 28.9651646 ],
-      "post_nr": 31
-    }
-    ,
-    {
-      "location": "Strasbourg",
-      "lat_lng": [ 48.56908, 7.7621 ],
-      "post_nr": 32
-    }
-    ,
-    {
-      "location": "Tilburg",
-      "lat_lng": [ 51.58508, 5.06369 ],
-      "post_nr": 33
-    }
-    ,
-    {
-      "location": "Saarbrücken",
-      "lat_lng": [ 49.24717, 6.98287 ],
-      "post_nr": 34
-    }
-    ,
-    {
-      "location": "Grenoble",
-      "lat_lng": [ 45.182478, 5.7210773 ],
-      "post_nr": 35
-    }
-  ]
+  "list": {{ page.fairphone_local_communities | jsonify }}
 }

--- a/fprsmap01.js
+++ b/fprsmap01.js
@@ -1,53 +1,52 @@
-//Custom Marker
+// Custom Marker
 var myIcon = L.icon({
-	iconUrl: 'FairphoneMarker.png',
-	iconSize: [31.8,50],
-	iconAnchor: [15.9,49]
+  iconUrl: 'FairphoneMarker.png',
+  iconSize: [31.8, 50],
+  iconAnchor: [15.9, 49],
 });
 
-//Map is initialized
-var fprsmap = L.map('mapid').setView([49.8158683,6.1296751], 4);
+// Map is initialized
+var fprsmap = L.map('mapid').setView([49.8158683, 6.1296751], 4);
 L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
-    maxZoom: 18
+  attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
+  maxZoom: 18,
 }).addTo(fprsmap);
 
-//List of Local Fairphone Communities (Source: https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815)
+// List of Local Fairphone Communities (Source: https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815)
 var groups = [
-	{loc:'Austria', latlng:[48.2083537,16.3725042], postnr:4},
-	{loc:'Canada', latlng:[	43.6529206,-79.3849007], postnr:22},
-	//Germany
-	{loc:'Aachen', latlng:[50.776351,6.0838618], postnr:6},
-	{loc:'Augsburg', latlng:[48.3668041,10.8986971], postnr:12},
-	{loc:'Berlin', latlng: [52.5170365,13.3888599], postnr:24},
-	{loc:'Bremen', latlng:[53.0758196,8.8071646], postnr:15},
-	{loc:'Düsseldorf', latlng:[51.2254018,6.7763137], postnr:8},
-	{loc:'Franken', latlng:[49.4538723,11.0772978], postnr:11},
-	{loc:'Hamburg', latlng:[53.5503414,10.000654], postnr:20},
-	{loc:'München', latlng:[48.1371079,11.5753822], postnr:23},
-   {loc:'Saarbrücken', latlng:[49.24717,6.98287], postnr:34},
-	{loc:'Stuttgart', latlng:[48.7784485,9.1800132], postnr:7},
-	{loc:'Ulm', latlng:[48.3973944,9.9932755], postnr:17},
-	//France
-   {loc:'Grenoble', latlng:[45.182478,5.7210773], postnr:35},
-	{loc:'Paris', latlng:[48.8566101,2.3514992], postnr:13},
-   {loc:'Strasbourg', latlng:[48.56908,7.76210], postnr:32},
-	//Israel
-	{loc:'Israel', latlng:[32.0804808,34.7805274], postnr:25},
-	//Netherlands
-	{loc:'Leiden', latlng:[52.1598645,4.4824271], postnr:21},
-   {loc:'Tilburg', latlng:[51.58508,5.06369], postnr:33}, 
-	{loc:'Spain', latlng:[41.3825596,2.1771353], postnr:5},
-	//Switzerland
-	{loc:'Aarau', latlng:[47.3927146,8.0444448], postnr:14},
-	{loc:'United Kingdom', latlng:[51.5073,-0.1277], postnr:28},
-	{loc:'Sweden', latlng:[63.8256568,20.2630745], postnr:29},
-   {loc:'Turkey', latlng:[41.0096334,28.9651646], postnr:31}
+  { loc: 'Austria', latlng: [48.2083537, 16.3725042], postnr: 4 },
+  { loc: 'Canada', latlng: [43.6529206, -79.3849007], postnr: 22 },
+  // Germany
+  { loc: 'Aachen', latlng: [50.776351, 6.0838618], postnr: 6 },
+  { loc: 'Augsburg', latlng: [48.3668041, 10.8986971], postnr: 12 },
+  { loc: 'Berlin', latlng: [52.5170365, 13.3888599], postnr: 24 },
+  { loc: 'Bremen', latlng: [53.0758196, 8.8071646], postnr: 15 },
+  { loc: 'Düsseldorf', latlng: [51.2254018, 6.7763137], postnr: 8 },
+  { loc: 'Franken', latlng: [49.4538723, 11.0772978], postnr: 11 },
+  { loc: 'Hamburg', latlng: [53.5503414, 10.000654], postnr: 20 },
+  { loc: 'München', latlng: [48.1371079, 11.5753822], postnr: 23 },
+  { loc: 'Saarbrücken', latlng: [49.24717, 6.98287], postnr: 34 },
+  { loc: 'Stuttgart', latlng: [48.7784485, 9.1800132], postnr: 7 },
+  { loc: 'Ulm', latlng: [48.3973944, 9.9932755], postnr: 17 },
+  // France
+  { loc: 'Grenoble', latlng: [45.182478, 5.7210773], postnr: 35 },
+  { loc: 'Paris', latlng: [48.8566101, 2.3514992], postnr: 13 },
+  { loc: 'Strasbourg', latlng: [48.56908, 7.76210], postnr: 32 },
+  // Israel
+  { loc: 'Israel', latlng: [32.0804808, 34.7805274], postnr: 25 },
+  // Netherlands
+  { loc: 'Leiden', latlng: [52.1598645, 4.4824271], postnr: 21 },
+  { loc: 'Tilburg', latlng: [51.58508, 5.06369], postnr: 33 },
+  { loc: 'Spain', latlng: [41.3825596, 2.1771353], postnr: 5 },
+  // Switzerland
+  { loc: 'Aarau', latlng: [47.3927146, 8.0444448], postnr: 14 },
+  { loc: 'United Kingdom', latlng: [51.5073, -0.1277], postnr: 28 },
+  { loc: 'Sweden', latlng: [63.8256568, 20.2630745], postnr: 29 },
+  { loc: 'Turkey', latlng: [41.0096334, 28.9651646], postnr: 31 },
 ];
 
-//Add a marker per Local Fairphone Community
-for(i=0;i<groups.length;i++) {
-	L.marker(groups[i].latlng,{icon: myIcon, riseOnHover: true}).addTo(fprsmap)
-		.bindPopup('<a href="https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815/' + groups[i].postnr + '" target="_blank">' + groups[i].loc + '</a>', {offset: new L.Point(0,-25)});
-	//L.circle(groups[i].latlng,50000, {stroke:false}).addTo(fprsmap)
-};
+// Add a marker per Local Fairphone Community
+for (i = 0; i < groups.length; i++) {
+  L.marker(groups[i].latlng, { icon: myIcon, riseOnHover: true }).addTo(fprsmap)
+    .bindPopup('<a href="https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815/' + groups[i].postnr + '" target="_blank">' + groups[i].loc + '</a>', { offset: new L.Point(0, -25) });
+}

--- a/fprsmap01.js
+++ b/fprsmap01.js
@@ -1,52 +1,51 @@
-// Custom Marker
-var myIcon = L.icon({
-  iconUrl: 'FairphoneMarker.png',
-  iconSize: [31.8, 50],
-  iconAnchor: [15.9, 49],
-});
+(function(global) {
+  'use strict';
 
-// Map is initialized
-var fprsmap = L.map('mapid').setView([49.8158683, 6.1296751], 4);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
-  maxZoom: 18,
-}).addTo(fprsmap);
+  /* Utils */
+  function fetchJSON(url) {
+    return fetch(url)
+      .then(function(response) {
+        return response.json();
+      });
+  }
 
-// List of Local Fairphone Communities (Source: https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815)
-var groups = [
-  { loc: 'Austria', latlng: [48.2083537, 16.3725042], postnr: 4 },
-  { loc: 'Canada', latlng: [43.6529206, -79.3849007], postnr: 22 },
-  // Germany
-  { loc: 'Aachen', latlng: [50.776351, 6.0838618], postnr: 6 },
-  { loc: 'Augsburg', latlng: [48.3668041, 10.8986971], postnr: 12 },
-  { loc: 'Berlin', latlng: [52.5170365, 13.3888599], postnr: 24 },
-  { loc: 'Bremen', latlng: [53.0758196, 8.8071646], postnr: 15 },
-  { loc: 'Düsseldorf', latlng: [51.2254018, 6.7763137], postnr: 8 },
-  { loc: 'Franken', latlng: [49.4538723, 11.0772978], postnr: 11 },
-  { loc: 'Hamburg', latlng: [53.5503414, 10.000654], postnr: 20 },
-  { loc: 'München', latlng: [48.1371079, 11.5753822], postnr: 23 },
-  { loc: 'Saarbrücken', latlng: [49.24717, 6.98287], postnr: 34 },
-  { loc: 'Stuttgart', latlng: [48.7784485, 9.1800132], postnr: 7 },
-  { loc: 'Ulm', latlng: [48.3973944, 9.9932755], postnr: 17 },
-  // France
-  { loc: 'Grenoble', latlng: [45.182478, 5.7210773], postnr: 35 },
-  { loc: 'Paris', latlng: [48.8566101, 2.3514992], postnr: 13 },
-  { loc: 'Strasbourg', latlng: [48.56908, 7.76210], postnr: 32 },
-  // Israel
-  { loc: 'Israel', latlng: [32.0804808, 34.7805274], postnr: 25 },
-  // Netherlands
-  { loc: 'Leiden', latlng: [52.1598645, 4.4824271], postnr: 21 },
-  { loc: 'Tilburg', latlng: [51.58508, 5.06369], postnr: 33 },
-  { loc: 'Spain', latlng: [41.3825596, 2.1771353], postnr: 5 },
-  // Switzerland
-  { loc: 'Aarau', latlng: [47.3927146, 8.0444448], postnr: 14 },
-  { loc: 'United Kingdom', latlng: [51.5073, -0.1277], postnr: 28 },
-  { loc: 'Sweden', latlng: [63.8256568, 20.2630745], postnr: 29 },
-  { loc: 'Turkey', latlng: [41.0096334, 28.9651646], postnr: 31 },
-];
+  /* Constants */
+  // Local Fairphone Communities forum thread
+  var FORUM_THREAD_URL = 'https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815';
 
-// Add a marker per Local Fairphone Community
-for (i = 0; i < groups.length; i++) {
-  L.marker(groups[i].latlng, { icon: myIcon, riseOnHover: true }).addTo(fprsmap)
-    .bindPopup('<a href="https://forum.fairphone.com/t/pencil2-local-fairphoners-address-book-fairphone-communities/3815/' + groups[i].postnr + '" target="_blank">' + groups[i].loc + '</a>', { offset: new L.Point(0, -25) });
-}
+  var CUSTOM_MARKER = L.icon({
+    iconUrl: 'FairphoneMarker.png',
+    iconSize: [31.8, 50],
+    iconAnchor: [15.9, 49],
+  });
+
+  /* Variables (state) */
+  var map;
+
+  /* Functions */
+  function initMap() {
+    map = L.map('mapid').setView([49.8158683, 6.1296751], 4);
+    var mapLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
+      maxZoom: 18,
+    });
+    mapLayer.addTo(map);
+  }
+
+  /* Main */
+  initMap();
+
+  fetchJSON('communities.json')
+    .then(function(json) {
+      // Add a marker per Local Fairphone Community
+      json.list.forEach(function(group) {
+        L.marker(group.lat_lng, { icon: CUSTOM_MARKER, riseOnHover: true })
+          .addTo(map)
+          .bindPopup(
+            '<a href="' + FORUM_THREAD_URL + '/' + group.post_nr + '" target="_blank">' + group.location + '</a>',
+            { offset: new L.Point(0, -25) }
+          );
+      });
+    });
+
+}(this));

--- a/fprsmap01.js
+++ b/fprsmap01.js
@@ -7,8 +7,8 @@ var myIcon = L.icon({
 
 // Map is initialized
 var fprsmap = L.map('mapid').setView([49.8158683, 6.1296751], 4);
-L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU GPLv3</a>',
   maxZoom: 18,
 }).addTo(fprsmap);
 

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
 	<link rel="stylesheet" href="fprsmap01.css" />
 
 	<link rel="stylesheet" href="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.css" />
-	<script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js"></script>
-	<script src="https://bowercdn.net/c/es6-promise-3.2.2/es6-promise.min.js"></script>
-	<script src="https://bowercdn.net/c/fetch-1.0.0/fetch.js"></script>
+	<script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js" integrity="sha384-Lh7SNUss9JoImCvc96eCUnLX3HvY4kb0UZCWZbYWvceJ+o5CJeOJqqNoheaGkNHT" crossorigin="anonymous"></script>
+	<script src="https://bowercdn.net/c/es6-promise-3.2.2/es6-promise.min.js" integrity="sha384-GF7IR8yT5028AbfHnSJSxX0Y1D+sicFNHXDyV1Hzcf4EISXdjP8uW0Q/0yFIHpTD" crossorigin="anonymous"></script>
+	<script src="https://bowercdn.net/c/fetch-1.0.0/fetch.js" integrity="sha384-j9GCh0V617Ks+uEOZnAhwzTOWu5lPIlPW3QYRSfEwXd+x7VqP1XHNLgj3AIX7Mo0" crossorigin="anonymous"></script>
 </head>
 <body>
 	<div id="mapid"></div>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 
 	<link rel="stylesheet" href="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.css" />
 	<script src="https://npmcdn.com/leaflet@0.7.7/dist/leaflet.js"></script>
+	<script src="https://bowercdn.net/c/es6-promise-3.2.2/es6-promise.min.js"></script>
+	<script src="https://bowercdn.net/c/fetch-1.0.0/fetch.js"></script>
 </head>
 <body>
 	<div id="mapid"></div>


### PR DESCRIPTION
This was just finished in Roboe/fprsmap@7e08fa2, but I added Roboe/fprsmap@644f3de too because data is more readable formated as [YAML](https://github.com/Roboe/fprsmap/blob/644f3de80daf1c5138c305712655663f7956d9bf/communities.json), as we talked, than as [JSON](https://github.com/Roboe/fprsmap/blob/7e08fa298f12f5816c4eef5e1df0e57af9032d32/communities.json).

Preview: https://roboe.github.io/fprsmap

Changelog:
* Complete rewrite of `fprsmap.js`:
   * follow Airbnb's [JavaScript Style Guide](https://github.com/airbnb/javascript) (EcmaScript 5)
   * clearly divide JavaScript sections, but keep the code in a single file
   * add `fetch` polyfill and query the communities JSON data (#8)
* Communities data:
   * formatted as YAML for easy external contributions (less error-prone syntax for non-coders)
   * sorted by forum post number, to track changes easily
* Security: Enabled SSL for map tiles (HTTPS)
* Security: Added Subresource Integrity (SRI) for the CDN's libraries

I've taken some decisions on my own, so any of the above points are open to discussion, of course, :)